### PR TITLE
fix: make init work when not behind a proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ Example:
 npm init stencil app my-stencil-app
 ```
 
+### Using a proxy
+
+If you are behind a proxy, configure `https_proxy` environment variable.
+
 ## Built-in starters
 
 - [app](https://github.com/ionic-team/stencil-app-starter)

--- a/src/download.ts
+++ b/src/download.ts
@@ -10,12 +10,12 @@ export function downloadStarter(starter: Starter) {
 function downloadFromURL(url: string): Promise<Buffer> {
 
     const options = Url.parse(url);
-    const httpsProxyString:string = process.env.https_proxy || "";
-    // @ts-ignore
-    const agent = new HttpsProxyAgentModule.default(httpsProxyString);
-    // @ts-ignore
-    options.agent = agent;
-
+    if (process.env.https_proxy) {
+        // @ts-ignore
+        const agent = new HttpsProxyAgentModule.default(process.env.https_proxy);
+        // @ts-ignore
+        options.agent = agent;
+    }
     return new Promise((resolve, reject) => {
         get(options, (res) => {
             if (res.statusCode === 302) {


### PR DESCRIPTION
If not using `https_proxy` env variable, it defaults to `127.0.0.1:80`.

Change the code to not use the proxy if `https_proxy` is not configured. 

closes https://github.com/ionic-team/create-stencil/issues/33