### PR TITLE
fix:fix package.json location

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.10.1",
   "description": "Quickly create a new stencil application: npm init stencil",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "start": "node index.js",
     "build.tsc": "tsc",

--- a/src/version.js
+++ b/src/version.js
@@ -1,5 +1,5 @@
 
 export function getPkgVersion() {
-  const pkg = require('../package.json');
+  const pkg = require('./package.json');
   return pkg.version;
 }


### PR DESCRIPTION
Currently `npm init stencil --info` not working, since it's looking for the package.json in the wrong directory.