### PR TITLE
feat: allow stencil starter to be downloaded from on prem registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm init stencil app my-stencil-app
 
 ### Using a proxy
 
-If you are behind a proxy, configure `https_proxy` environment variable.
+If you are behind a proxy, configure `https_proxy` environment variable. Additionally, if you are self-hosting a repository, you can set `STENCIL_DOWNLOAD_URL=https://your-on-prem-registry.com` in your npm config (`.npmrc`) file to download the starter app from this registry. The default is `https://github.com`.
 
 ## Built-in starters
 

--- a/src/download.ts
+++ b/src/download.ts
@@ -4,7 +4,8 @@ import { Starter } from './starters';
 import * as HttpsProxyAgentModule from 'https-proxy-agent';
 
 export function downloadStarter(starter: Starter) {
-  return downloadFromURL(`https://github.com/${starter.repo}/archive/master.zip`);
+  const hostUrl = process.env.npm_config_stencil_download_url || 'https://github.com';
+  return downloadFromURL(`${hostUrl}/${starter.repo}/archive/master.zip`);
 }
 
 function downloadFromURL(url: string): Promise<Buffer> {


### PR DESCRIPTION
When working behind a corporate proxy, requests to github.com might be rejected by the proxy. Often companies who use a corporate proxy also have an on-prem registry for npm packages. This PR allows to set the host URL to get the starter app from which allows stencil to be initialized behind a strict proxy.