### PR TITLE
feat(cli): remove ionic-pwa option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 index.js
 .DS_store
+.idea/

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ If you are behind a proxy, configure `https_proxy` environment variable.
 
 - [app](https://github.com/ionic-team/stencil-app-starter)
 - [components](https://github.com/ionic-team/stencil-component-starter)
-- [ionic-pwa](https://github.com/ionic-team/ionic-pwa-toolkit)
 
 ## Developing locally
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "stencil",
     "stenciljs",
     "web components",
-    "pwa",
     "create-app",
     "cli",
     "progress web app",

--- a/src/starters.ts
+++ b/src/starters.ts
@@ -26,12 +26,6 @@ export const STARTERS: Starter[] = [
     description: 'Minimal starter for building a Stencil app or website',
     docs: 'https://github.com/ionic-team/stencil-app-starter',
   },
-  {
-    name: 'ionic-pwa',
-    repo: 'ionic-team/ionic-pwa-toolkit',
-    description: '(deprecated) Everything you need to build fast, production ready PWAs',
-    docs: 'https://ionicframework.com/docs',
-  },
 ];
 
 export function getStarterRepo(starterName: string): Starter {

--- a/src/starters.ts
+++ b/src/starters.ts
@@ -8,18 +8,6 @@ export interface Starter {
 
 export const STARTERS: Starter[] = [
   {
-    name: 'ionic-pwa',
-    repo: 'ionic-team/ionic-pwa-toolkit',
-    description: 'Everything you need to build fast, production ready PWAs',
-    docs: 'https://ionicframework.com/docs',
-  },
-  {
-    name: 'app',
-    repo: 'ionic-team/stencil-app-starter',
-    description: 'Minimal starter for building a Stencil app or website',
-    docs: 'https://github.com/ionic-team/stencil-app-starter',
-  },
-  {
     name: 'component',
     repo: 'ionic-team/stencil-component-starter',
     description: 'Collection of web components that can be used anywhere',
@@ -31,6 +19,18 @@ export const STARTERS: Starter[] = [
     description: 'Collection of web components that can be used anywhere',
     docs: 'https://github.com/ionic-team/stencil-component-starter',
     hidden: true,
+  },
+  {
+    name: 'app',
+    repo: 'ionic-team/stencil-app-starter',
+    description: 'Minimal starter for building a Stencil app or website',
+    docs: 'https://github.com/ionic-team/stencil-app-starter',
+  },
+  {
+    name: 'ionic-pwa',
+    repo: 'ionic-team/ionic-pwa-toolkit',
+    description: '(deprecated) Everything you need to build fast, production ready PWAs',
+    docs: 'https://ionicframework.com/docs',
   },
 ];
 

--- a/src/vendor/prompts/elements/select.js
+++ b/src/vendor/prompts/elements/select.js
@@ -1,4 +1,4 @@
-import { bold, cyan, gray, green, yellow } from 'colorette';
+import { bold, cyan, gray, green } from 'colorette';
 import { Prompt } from './prompt';
 import { style, clear, figures } from '../util';
 import { erase, cursor } from 'sisteransi';
@@ -98,8 +98,7 @@ export class SelectPrompt extends Prompt {
         '\n\n' +
           this.values
             .map((v, i) => {
-              let title = v.title.replace('(deprecated)', yellow('(deprecated)'));
-              title = this.cursor === i ? cyan(title) : title;
+              let title = this.cursor === i ? cyan(v.title) : v.title;
               let prefix = this.cursor === i ? cyan(figures.pointer) + ' ' : '  ';
               return `${prefix} ${title}`;
             })

--- a/src/vendor/prompts/elements/select.js
+++ b/src/vendor/prompts/elements/select.js
@@ -1,4 +1,4 @@
-import { bold, cyan, gray, green } from 'colorette';
+import { bold, cyan, gray, green, yellow } from 'colorette';
 import { Prompt } from './prompt';
 import { style, clear, figures } from '../util';
 import { erase, cursor } from 'sisteransi';
@@ -98,7 +98,8 @@ export class SelectPrompt extends Prompt {
         '\n\n' +
           this.values
             .map((v, i) => {
-              let title = this.cursor === i ? cyan(v.title) : v.title;
+              let title = v.title.replace('(deprecated)', yellow('(deprecated)'));
+              title = this.cursor === i ? cyan(title) : title;
               let prefix = this.cursor === i ? cyan(figures.pointer) + ' ' : '  ';
               return `${prefix} ${title}`;
             })


### PR DESCRIPTION
remove the ionic-pwa option from the create-stencil cli. ionic is
planning on deprecating this starter, begin that deprecation process
on the stencil-side by no longer allowing it as an option. technically, this
is a breaking change, unless folks feel strongly this should simply go
in a minor version update.

the 'component' option was placed above the 'app' option to begin to
direct folks to start spinning up component libraries by default.

`.idea/` was also added to `.gitignore` as a separate commit, which follows
the pattern used in the stencil core repo.

## testing

to test, ran `npm run dev` to build the project, and verify the ordering of the options:
![Screen Shot 2021-12-29 at 10 44 09 AM](https://user-images.githubusercontent.com/1930213/147679285-1a357cc7-96d7-40a4-b393-02a520c87a95.png)

## doc changes
https://github.com/ionic-team/stencil-site/pull/808