### PR TITLE
chore(npm): add stub testing script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build": "npm run build.tsc && npm run build.bundle && npm run minify",
     "build.dev": "npm run build.tsc && npm run build.bundle",
     "dev": "npm run build.dev && npm start",
+    "test": "echo \"TODO(STENCIL-327): Add tests to create-stencil CLI\"",
     "version": "npm build",
     "release": "np"
   },


### PR DESCRIPTION
# Changes

add a 'stub' testing script to `package.json`. the create-stencil cli
currently has a release process that differs from stencil core in that
it (in theory) uses `np` for performing releases (suggested by the
'release' script in `package.json`). however, 'release' will not run
prior to this commit due to a lack of 'test' command. this suggests to
me the package was version bumped and released manually (using
`npm version` and `npm publish`, respectively).

to push the project towards a uniform (and arguably safer) publish process,
add a stub testing script so that 'release' (which is a proxy for `np`)
does not fail. the project does not have any tests at the moment.
although this is tech-debt that must begin to be remedied, we don't add
any in this commit for the sake of unblocking publish

# Testing
- `npm t` was run
- `npm run release -- --any-branch --preview` was run to perform a dry-run of the publish process (to verify nothing else was needed to run `np`)