### PR TITLE
chore(npm): remove version script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "build.dev": "npm run build.tsc && npm run build.bundle",
     "dev": "npm run build.dev && npm start",
     "test": "echo \"TODO(STENCIL-327): Add tests to create-stencil CLI\"",
-    "version": "npm build",
     "release": "np"
   },
   "engines": {


### PR DESCRIPTION
remove the version script from `package.json`, as it's not required by
np to bump the version (and the script is malformed as is, it's missing
the 'run' command between 'npm' and 'build')