### PR TITLE
feat(completion-text): reorder next steps after bootstrap

### DIFF
--- a/src/create-app.ts
+++ b/src/create-app.ts
@@ -36,6 +36,14 @@ export async function createApp(starter: Starter, projectName: string, autoRun: 
   const time = printDuration(Date.now() - startT);
   console.log(`${green('✔')} ${bold('All setup')} ${onlyUnix('🎉')} ${dim(time)}
 
+  ${dim('We suggest that you begin by typing:')}
+
+  ${dim(terminalPrompt())} ${green('cd')} ${projectName}
+  ${dim(terminalPrompt())} ${green('npm install')}
+  ${dim(terminalPrompt())} ${green('npm start')}
+
+  ${dim('You may find the following commands will be helpful:')}
+
   ${dim(terminalPrompt())} ${green('npm start')}
     Starts the development server.
 
@@ -45,12 +53,6 @@ export async function createApp(starter: Starter, projectName: string, autoRun: 
   ${dim(terminalPrompt())} ${green('npm test')}
     Starts the test runner.
 
-
-  ${dim('We suggest that you begin by typing:')}
-
-   ${dim(terminalPrompt())} ${green('cd')} ${projectName}
-   ${dim(terminalPrompt())} ${green('npm install')}
-   ${dim(terminalPrompt())} ${green('npm start')}
 ${renderDocs(starter)}
 
   Happy coding! 🎈


### PR DESCRIPTION
reorder the commands printed to the console after bootstrapping an
project. this is done to make the 'flow' of developing a new stencil
project smoother where before we created the project, would tell folks
about starting the dev server, then tell them to `cd` to the project's
directory to run `npm install` to be able to run those command

Testing:
Tested locally with `npm run dev`
![Screen Shot 2022-02-10 at 8 18 32 AM](https://user-images.githubusercontent.com/1930213/153416172-b0145820-462d-45cb-a1f4-cdeecce7a2ec.png)
s

Notes:
Once we're happy on verbiage and whatnot, I'll create a PR to update the getting started [documentation on the Stencil site this corresponds to ](https://stenciljs.com/docs/getting-started) - the initial PR is https://github.com/ionic-team/stencil-site/pull/835