### PR TITLE
chore(downloads): update path to starters

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -4,7 +4,7 @@ import { Starter } from './starters';
 import * as HttpsProxyAgentModule from 'https-proxy-agent';
 
 export function downloadStarter(starter: Starter) {
-  return downloadFromURL(`https://github.com/${starter.repo}/archive/master.zip`);
+  return downloadFromURL(`https://github.com/${starter.repo}/archive/main.zip`);
 }
 
 function downloadFromURL(url: string): Promise<Buffer> {


### PR DESCRIPTION
update the path to the starters that we currently support. this is being
done after moving each of their primary branches from 'master' to
'main'. this change doesn't need to be rushed out into production, as
redirects on github's side should suffice for some time

testing:
- verified the new paths, https://github.com/ionic-team/stencil-app-starter/archive/main.zip and https://github.com/ionic-team/stencil-component-starter/archive/main.zip resolved to a downloadable archive by entering the URL in the browser