### PR TITLE
chore(github): add ionitron to the repo

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -71,7 +71,7 @@ noReproduction:
   dryRun: false
 
 stale:
-  days: 180
+  days: 30
   maxIssuesPerRun: 100
   exemptLabels:
     - "Bug: Validated"

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -32,12 +32,12 @@ comment:
         need a code reproduction.
 
 
-        Please reproduce this issue in an Stencil starter component library and provide a way for us to access it
-        (GitHub repo, StackBlitz, etc). Without a reliable code reproduction, it is unlikely we will be able to resolve
-        the issue, leading to it being closed.
+        Please provide step-by-step instructions to reproduce your error. Be sure to include your operating system,
+        node version, the shell you are using, and any other information that you feel may be useful in reproducing the
+        error.
 
 
-        If you have already provided a code snippet and are seeing this message, it is likely that the code snippet was
+        If you have already provided a instructions and are seeing this message, it is likely that the instructions were
         not enough for our team to reproduce the issue.
 
 
@@ -104,7 +104,7 @@ wrongRepo:
       repo: ionic-cli
       message: >
         Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
-        associated with Stencil. It appears that this issue is associated with the Ionic CLI.
+        associated with the Stencil CLI. It appears that this issue is associated with the Ionic CLI.
         I am moving this issue to the Ionic CLI repository. Please track this issue over there.
 
 
@@ -113,7 +113,7 @@ wrongRepo:
       repo: ionic
       message: >
         Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
-        associated with Stencil. It appears that this issue is associated with the Ionic Framework.
+        associated with Stencil CLI. It appears that this issue is associated with the Ionic Framework.
         I am moving this issue to the Ionic Framework repository. Please track this issue over there.
 
 

--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -1,0 +1,123 @@
+triage:
+  label: triage
+  dryRun: false
+
+closeAndLock:
+  labels:
+    - label: "ionitron: support"
+      message: >
+        Thanks for the issue! This issue appears to be a support request. We use this issue tracker exclusively for
+        bug reports and feature requests. Please use our [slack channel](https://stencil-worldwide.herokuapp.com/)
+        for questions about Stencil.
+
+
+        Thank you for using Stencil!
+    - label: "ionitron: missing template"
+      message: >
+        Thanks for the issue! It appears that you have not filled out the provided issue template. We use this issue
+        template in order to gather more information and further assist you. Please create a new issue and ensure the
+        template is fully filled out.
+
+
+        Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false
+
+comment:
+  labels:
+    - label: "ionitron: needs reproduction"
+      message: >
+        Thanks for the issue! This issue has been labeled as `needs reproduction`. This label is added to issues that
+        need a code reproduction.
+
+
+        Please reproduce this issue in an Stencil starter component library and provide a way for us to access it
+        (GitHub repo, StackBlitz, etc). Without a reliable code reproduction, it is unlikely we will be able to resolve
+        the issue, leading to it being closed.
+
+
+        If you have already provided a code snippet and are seeing this message, it is likely that the code snippet was
+        not enough for our team to reproduce the issue.
+
+
+        For a guide on how to create a good reproduction, see our
+        [Contributing Guide](https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md).
+  dryRun: false
+
+noReply:
+  maxIssuesPerRun: 100
+  includePullRequests: false
+  label: Awaiting Reply
+  close: false
+  lock: false
+  dryRun: false
+
+noReproduction:
+  days: 14
+  maxIssuesPerRun: 100
+  label: "ionitron: needs reproduction"
+  responseLabel: triage
+  exemptProjects: true
+  exemptMilestones: true
+  message: >
+    Thanks for the issue! This issue is being closed due to the lack of a code reproduction. If this is still
+    an issue with the latest version of Stencil, please create a new issue and ensure the template is fully filled out.
+
+
+    Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false
+
+stale:
+  days: 180
+  maxIssuesPerRun: 100
+  exemptLabels:
+    - "Bug: Validated"
+    - "Feature: Want this? Upvote it!"
+    - good first issue
+    - help wanted
+    - Reply Received
+    - Request For Comments
+    - "Resolution: Needs Investigation"
+    - "Resolution: Refine"
+    - triage
+  exemptAssigned: true
+  exemptProjects: true
+  exemptMilestones: true
+  label: "ionitron: stale issue"
+  message: >
+    Thanks for the issue! This issue is being closed due to inactivity. If this is still
+    an issue with the latest version of Stencil, please create a new issue and ensure the
+    template is fully filled out.
+
+
+    Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false
+
+wrongRepo:
+  repos:
+    - label: "ionitron: cli"
+      repo: ionic-cli
+      message: >
+        Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
+        associated with Stencil. It appears that this issue is associated with the Ionic CLI.
+        I am moving this issue to the Ionic CLI repository. Please track this issue over there.
+
+
+        Thank you for using Stencil!
+    - label: "ionitron: ionic"
+      repo: ionic
+      message: >
+        Thanks for the issue! We use this issue tracker exclusively for bug reports and feature requests
+        associated with Stencil. It appears that this issue is associated with the Ionic Framework.
+        I am moving this issue to the Ionic Framework repository. Please track this issue over there.
+
+
+        Thank you for using Stencil!
+  close: true
+  lock: true
+  dryRun: false


### PR DESCRIPTION
this commit adds our internal bot 'ionitron' to the create-stencil
repository. technically, ionitron is already configured for the repo,
but needs a configuration file (this commit) to run.

this commit adds the ionitron configuration from the stencil core
compiler repository at
https://github.com/ionic-team/stencil/blob/9bfef1ad4637fe82c349eadbd9153e04417b1337/.github/ionic-issue-bot.yml.
it is a direct copy to keep the behavior similar between repositories
(making the behavior easier to grok for maintainers) with a few minor changes:
- have ionitron mark issues as stale after 30 days. 180 is too long in our
opinion, as is going to be changed in the stencil repository soon (4db5bec2939554184f2f606e1f236e47c6e5de14)
- messages to the user have been tailored to the Create Stencil CLI, rather
than the core compiler (57b6ccdf2b455b2bdc95342b22f13565b6ea2c03)