### PR TITLE
feat(community): be able to designate starters as community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ npm i -g npm
 
 To install latest version of `npm`
 
+## Starters
+
+The create-stencil CLI offers the following starters for bootstrapping your project:
+
+- `component` - allows one to spin up a component library containing one or more Stencil components. Best suited for
+teams/individuals looking to reuse components across one or more applications.
+- `application` - allows one to spin up an application, complete with routing. This is a **community-driven** project,
+and is not formally owned by the Stencil team
+
 ## Usage
 
 
@@ -28,7 +37,7 @@ npm init stencil <starter> <projectName>
 Example:
 
 ```
-npm init stencil app my-stencil-app
+npm init stencil component my-stencil-library
 ```
 
 ### Using a proxy

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -43,7 +43,7 @@ async function askStarterName(): Promise<string> {
     {
       type: 'select',
       name: 'starterName',
-      message: `Select a starter project. Starters marked as ${COMMUNITY_PREFIX} are developed by the Stencil Community, rather than Ionic. For more information on the Stencil Community, please see https://github.com/stencil-community`,
+      message: 'Pick a starter',
       choices: getChoices(),
     },
     {

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -4,6 +4,9 @@ import { dim } from 'colorette';
 import { createApp, prepareStarter } from './create-app';
 import { STARTERS, Starter, getStarterRepo } from './starters';
 
+/**
+ * A prefix for community-driven projects
+ */
 const COMMUNITY_PREFIX = '[Community]';
 
 export async function runInteractive(starterName: string | undefined, autoRun: boolean) {
@@ -31,6 +34,10 @@ export async function runInteractive(starterName: string | undefined, autoRun: b
   }
 }
 
+/**
+ * Prompt the user for the name of a starter project to bootstrap with
+ * @returns the name of the starter project to use
+ */
 async function askStarterName(): Promise<string> {
   const { starterName }: any = await prompt([
     {
@@ -51,7 +58,11 @@ async function askStarterName(): Promise<string> {
   return starterName;
 }
 
-function getChoices() {
+/**
+ * Generate a terminal-friendly list of options for the user to select from
+ * @returns a formatted list of starter options
+ */
+function getChoices(): ReadonlyArray<{title: string, value: string}> {
   const maxLength = Math.max(...STARTERS.map(s => generateStarterName(s).length)) + 1;
   return [
     ...STARTERS
@@ -66,7 +77,13 @@ function getChoices() {
   ];
 }
 
+/**
+ * Generate the user-displayed name of the starter project
+ * @param starter the starter project to format
+ * @returns the formatted name
+ */
 function generateStarterName(starter: Starter): string {
+  // ensure that community packages are differentiated from those supported by Ionic/the Stencil team
   return starter.isCommunity ? `${COMMUNITY_PREFIX} ${starter.name}` : starter.name;
 }
 

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -43,7 +43,7 @@ async function askStarterName(): Promise<string> {
     {
       type: 'select',
       name: 'starterName',
-      message: 'Select a starter project. Starters marked as ' + COMMUNITY_PREFIX + ' are developed by the Stencil Community, rather than Ionic. For more information on the Stencil Community, please see https://github.com/stencil-community',
+      message: `Select a starter project. Starters marked as ${COMMUNITY_PREFIX} are developed by the Stencil Community, rather than Ionic. For more information on the Stencil Community, please see https://github.com/stencil-community`,
       choices: getChoices(),
     },
     {

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -4,6 +4,8 @@ import { dim } from 'colorette';
 import { createApp, prepareStarter } from './create-app';
 import { STARTERS, Starter, getStarterRepo } from './starters';
 
+const COMMUNITY_PREFIX = '[Community]';
+
 export async function runInteractive(starterName: string | undefined, autoRun: boolean) {
   process.stdout.write(erase.screen);
   process.stdout.write(cursor.to(0, 1));
@@ -34,7 +36,7 @@ async function askStarterName(): Promise<string> {
     {
       type: 'select',
       name: 'starterName',
-      message: 'Pick a starter',
+      message: 'Select a starter project. Starters marked as ' + COMMUNITY_PREFIX + ' are developed by the Stencil Community, rather than Ionic. For more information on the Stencil Community, please see https://github.com/stencil-community',
       choices: getChoices(),
     },
     {
@@ -50,18 +52,22 @@ async function askStarterName(): Promise<string> {
 }
 
 function getChoices() {
-  const maxLength = Math.max(...STARTERS.map(s => s.name.length)) + 1;
+  const maxLength = Math.max(...STARTERS.map(s => generateStarterName(s).length)) + 1;
   return [
     ...STARTERS
       .filter(s => s.hidden !== true)
       .map(s => {
         const description = s.description ? dim(s.description) : '';
         return {
-          title: `${padEnd(s.name, maxLength)}   ${description}`,
+          title: `${padEnd(generateStarterName(s), maxLength)}   ${description}`,
           value: s.name,
         };
       }),
   ];
+}
+
+function generateStarterName(starter: Starter): string {
+  return starter.isCommunity ? `${COMMUNITY_PREFIX} ${starter.name}` : starter.name;
 }
 
 async function askProjectName() {

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -7,7 +7,7 @@ import { STARTERS, Starter, getStarterRepo } from './starters';
 /**
  * A prefix for community-driven projects
  */
-const COMMUNITY_PREFIX = '[Community]';
+const COMMUNITY_PREFIX = '[community]';
 
 export async function runInteractive(starterName: string | undefined, autoRun: boolean) {
   process.stdout.write(erase.screen);
@@ -43,7 +43,16 @@ async function askStarterName(): Promise<string> {
     {
       type: 'select',
       name: 'starterName',
-      message: 'Pick a starter',
+      /**
+       * the width of this message is intentionally kept to ~80 characters. this is a slightly arbitrary decision to
+       * prevent one long single line message in wide terminal windows. this _should_ be changeable without any
+       * negative impact on the code.
+       */
+      message: `Select a starter project.
+
+Starters marked as ${COMMUNITY_PREFIX} are developed by the Stencil Community,
+rather than Ionic. For more information on the Stencil Community, please see
+https://github.com/stencil-community`,
       choices: getChoices(),
     },
     {

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -52,13 +52,15 @@ async function askStarterName(): Promise<string> {
 function getChoices() {
   const maxLength = Math.max(...STARTERS.map(s => s.name.length)) + 1;
   return [
-    ...STARTERS.filter(s => s.hidden !== true).map(s => {
-      const description = s.description ? dim(s.description) : '';
-      return {
-        title: `${padEnd(s.name, maxLength)}   ${description}`,
-        value: s.name,
-      };
-    }),
+    ...STARTERS
+      .filter(s => s.hidden !== true)
+      .map(s => {
+        const description = s.description ? dim(s.description) : '';
+        return {
+          title: `${padEnd(s.name, maxLength)}   ${description}`,
+          value: s.name,
+        };
+      }),
   ];
 }
 

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -93,7 +93,7 @@ function getChoices(): ReadonlyArray<{title: string, value: string}> {
  */
 function generateStarterName(starter: Starter): string {
   // ensure that community packages are differentiated from those supported by Ionic/the Stencil team
-  return starter.isCommunity ? `${COMMUNITY_PREFIX} ${starter.name}` : starter.name;
+  return starter.isCommunity ? `${starter.name} ${COMMUNITY_PREFIX}` : starter.name;
 }
 
 async function askProjectName() {

--- a/src/starters.ts
+++ b/src/starters.ts
@@ -4,6 +4,7 @@ export interface Starter {
   description?: string;
   docs?: string;
   hidden?: boolean;
+  isCommunity?: boolean;
 }
 
 export const STARTERS: Starter[] = [
@@ -25,6 +26,7 @@ export const STARTERS: Starter[] = [
     repo: 'ionic-team/stencil-app-starter',
     description: 'Minimal starter for building a Stencil app or website',
     docs: 'https://github.com/ionic-team/stencil-app-starter',
+    isCommunity: true,
   },
 ];
 

--- a/src/starters.ts
+++ b/src/starters.ts
@@ -1,12 +1,38 @@
+/**
+ * Metadata for a starter project that the CLI will use to bootstrap a user's project.
+ */
 export interface Starter {
+  /**
+   * The name of the starter.
+   */
   name: string;
+  /**
+   * The GitHub repository the starter can be found in. The base URL is assumed to exist and does not need to be
+   * provided.
+   */
   repo: string;
+  /**
+   * A brief description of the starter project.
+   */
   description?: string;
+  /**
+   * A link to the starter's documentation.
+   */
   docs?: string;
+  /**
+   * When true, the starter should be hidden from the list of possible choices. This allows the `name` to be used with
+   * the `npm init stencil component <NAME>` command, without cluttering the options list.
+   */
   hidden?: boolean;
+  /**
+   * When true, the starter is a community-driven project, rather than one owned by Ionic
+   */
   isCommunity?: boolean;
 }
 
+/**
+ * Existing Stencil project starters available for CLI users to select from
+ */
 export const STARTERS: Starter[] = [
   {
     name: 'component',
@@ -30,6 +56,14 @@ export const STARTERS: Starter[] = [
   },
 ];
 
+/**
+ * Retrieve a starter project's metadata based on a CLI user's input.
+ *
+ * @param starterName the name of the starter project to retrieve. Starter names that include a forward slash ('/') are
+ * assumed to be custom starter templates. Such templates are assumed to be the name of the repository that this CLI
+ * can retrieve the starter template from.
+ * @returns the starter project metadata
+ */
 export function getStarterRepo(starterName: string): Starter {
   if (starterName.includes('/')) {
     return {

--- a/src/starters.ts
+++ b/src/starters.ts
@@ -33,7 +33,7 @@ export interface Starter {
 /**
  * Existing Stencil project starters available for CLI users to select from
  */
-export const STARTERS: Starter[] = [
+export const STARTERS: ReadonlyArray<Starter> = [
   {
     name: 'component',
     repo: 'ionic-team/stencil-component-starter',


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Today, the app starter is currently an Ionic-owned project. This PR adds the ability to denote projects as 'community driven' and sets the app starter as such

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->


this commit adds the ability for the starter selection ux to denote
which starter projects are community driven.

this is accomplished by adding an optional `isCommunity` field to the
pre-existing starter metadata, and setting that field to `true` for the
application starter.

starters that are designated as community-driven will appear a such in
the picker:

![Screen Shot 2022-05-17 at 9 13 03 AM](https://user-images.githubusercontent.com/1930213/168819358-2aa4ab9f-0cdc-4da8-bf7c-fd3bfab4ccd5.png)



~the disclaimer/explanation of the community nomenclature must be placed
on one line at this time. if any newlines appear in this string, the
explanation will reprint on every arrow key movement.~
Update: Fixed in https://github.com/ionic-team/create-stencil/pull/69

~the good news is that for the terminals/shells I tested, this text always wrapped properly (unlike what it's doing in GH above)~

~Update: this isn't true - any time the text overflows the width of the window, it doesn't erase correctly.~
Update 2: Fixed in https://github.com/ionic-team/create-stencil/pull/69 



## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

Designates the application starter as 'community driven' - which is _kind of_ a breaking change.  We're going to roll this out in a major release to avoid any confusion in so far as we can

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

There's no formal testing infrastructure for this project at the moment. This has to be manually tested. (I added STENCIL-449 to start this effort, although it'll span multiple tickets)

When this package is built for production, an `index.js` file is generated in the root of the repo.  We build this package with `npm run build`, and copy the resulting `index.js` file to a temp directory to test

**Provide no CLI options**
`node index.js` (select 'app', then give the name 'stencil-app')
`cd stencil-app`
`npm i`
`npm run build`
`npm t`


**Provide starter CLI option**
`node index.js app` (give the name 'my-app')
`cd my-app`
`npm i`
`npm run build`
`npm t`

**Provide all CLI options**
`node index.js app another-stencil-app`
`cd another-stencil-app`
`npm i`
`npm run build`
`npm t`

**Cancelling after Providing a Starter**
![Screen Shot 2022-05-17 at 9 20 38 AM](https://user-images.githubusercontent.com/1930213/168820767-711435df-5588-4fa4-8fd3-7ae7372c70ef.png)

**Cancelling on Confirmation Prompt**
![Screen Shot 2022-05-17 at 9 21 01 AM](https://user-images.githubusercontent.com/1930213/168820804-5b063afc-fa0d-4128-8d61-6b83f8383991.png)

**Cycling Thru Options**
One should be able to cycle thru all the options with the arrow keys without the options reprinting

