### PR TITLE
feat(app-starter): update url for community

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The create-stencil CLI offers the following starters for bootstrapping your proj
 
 - `component` - allows one to spin up a component library containing one or more Stencil components. Best suited for
 teams/individuals looking to reuse components across one or more applications.
-- `application` - allows one to spin up an application, complete with routing. This is a **community-driven** project,
+- `app` - allows one to spin up an application, complete with routing. This is a **community-driven** project,
 and is not formally owned by the Stencil team
 
 ## Usage
@@ -46,8 +46,8 @@ If you are behind a proxy, configure `https_proxy` environment variable.
 
 ## Built-in starters
 
-- [app](https://github.com/ionic-team/stencil-app-starter)
-- [components](https://github.com/ionic-team/stencil-component-starter)
+- [app (community-maintained)](https://github.com/stencil-community/stencil-app-starter)
+- [component](https://github.com/ionic-team/stencil-component-starter)
 
 ## Developing locally
 

--- a/src/starters.ts
+++ b/src/starters.ts
@@ -49,9 +49,9 @@ export const STARTERS: ReadonlyArray<Starter> = [
   },
   {
     name: 'app',
-    repo: 'ionic-team/stencil-app-starter',
+    repo: 'stencil-community/stencil-app-starter',
     description: 'Minimal starter for building a Stencil app or website',
-    docs: 'https://github.com/ionic-team/stencil-app-starter',
+    docs: 'https://github.com/stencil-community/stencil-app-starter',
     isCommunity: true,
   },
 ];


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The app starter for Stencil projects points to the [github.com/ionic-team/stencil-app-starter](https://github.com/ionic-team/stencil-app-starter) repository. We're going to be moving that starter to the community, and need to update the URL accordingly

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit points the application starter location to its new home in
the stencil community.

this was kept separate from #68, as there's a certain order of operations that must occur here:
1. the app starter is moved to the stencil-community
2. this PR is merged, pointing the CLI to the stencil-community version of the app starter
3. a new version of the create-stencil CLI is created/published to NPM, making the changes available to all

should we need to back out and revert changes temporarily, this allows us to point back to the stencil-app starter 
while its owned by the ionic-team

## Does this introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

This has not been tested, as it requires transferring ownership of the repo.

Code owners please scrutinize the changes here (another reason I kept this PR small)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
