### PR TITLE
fix(cli): fix --info flag

### DIFF
--- a/src/create-app.ts
+++ b/src/create-app.ts
@@ -5,7 +5,7 @@ import { bold, cyan, dim, green } from 'colorette';
 import { downloadStarter } from './download';
 import { Starter } from './starters';
 import { unZipBuffer } from './unzip';
-import { npm, onlyUnix, printDuration, renameAsync, setTmpDirectory, terminalPrompt } from './utils';
+import { npm, onlyUnix, printDuration, setTmpDirectory, terminalPrompt } from './utils';
 import { replaceInFile } from 'replace-in-file';
 
 const starterCache = new Map<Starter, Promise<undefined | ((name: string) => Promise<void>)>>();
@@ -98,7 +98,7 @@ async function prepare(starter: Starter) {
 
   return async (projectName: string) => {
     const filePath = join(baseDir, projectName);
-    await renameAsync(tmpPath, filePath);
+    await fs.promises.rename(tmpPath, filePath);
     await replaceInFile({
       files: [join(filePath, '*'), join(filePath, 'src/*')],
       from: /stencil-starter-project-name/g,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,6 @@ import { ChildProcess, spawn } from 'child_process';
 import fs from 'fs';
 import { join } from 'path';
 import { yellow } from 'colorette';
-import { promisify } from 'util';
 
 const childrenProcesses: ChildProcess[] = [];
 let tmpDirectory: string | null = null;
@@ -83,8 +82,6 @@ export function terminalPrompt() {
   return isWin() ? '>' : '$';
 }
 
-export const renameAsync = promisify(fs.rename);
-
 export function nodeVersionWarning() {
   try {
     const v = process.version.replace('v', '').split('.');
@@ -99,3 +96,11 @@ export function nodeVersionWarning() {
     }
   } catch (e) {}
 }
+
+/**
+ * Returns the result of attempting to `require` the project's `package.json`
+ * @returns the result of a `require()` statement
+ */
+export const getPackageJson = () => {
+  return require('./package.json');
+};

--- a/src/version.js
+++ b/src/version.js
@@ -1,4 +1,0 @@
-export function getPkgVersion() {
-  const pkg = require('../package.json');
-  return pkg.version;
-}

--- a/src/version.spec.ts
+++ b/src/version.spec.ts
@@ -1,0 +1,34 @@
+import { getPkgVersion } from './version';
+import * as utils from './utils';
+
+describe('version', () => {
+  describe('getPkgVersion', () => {
+    let getPackageJsonSpy: jest.SpyInstance<
+      ReturnType<typeof utils.getPackageJson>,
+      Parameters<typeof utils.getPackageJson>
+    >;
+
+    beforeEach(() => {
+      getPackageJsonSpy = jest.spyOn(utils, 'getPackageJson');
+      getPackageJsonSpy.mockImplementation(() => ({ version: '0.0.0' }));
+    });
+
+    afterEach(() => {
+      getPackageJsonSpy.mockRestore();
+    });
+
+    it('throws if package.json cannot be found', () => {
+      getPackageJsonSpy.mockImplementation(() => null);
+      expect(() => getPkgVersion()).toThrow('the version of this package could not be determined');
+    });
+
+    it('throws if the version number cannot be found in package.json', () => {
+      getPackageJsonSpy.mockImplementation(() => ({}));
+      expect(() => getPkgVersion()).toThrow('the version of this package could not be determined');
+    });
+
+    it('returns the version number found in package.json', () => {
+      expect(getPkgVersion()).toBe('0.0.0');
+    });
+  });
+});

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,23 @@
+/**
+ * Pull the current version of the CLI from the project's `package.json` file.
+ *
+ * @returns the current version of this CLI
+ */
+import { getPackageJson } from './utils';
+
+export function getPkgVersion(): string {
+  let packageJson: any = null;
+
+  try {
+    packageJson = getPackageJson();
+  } catch (e) {
+    // do nothing, we'll check that the package.json file could be found
+    // and that it has a version field in the same check
+  }
+
+  if (!packageJson || !packageJson.version) {
+    throw 'the version of this package could not be determined';
+  }
+
+  return packageJson.version;
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `--info` flag fails like so:
```
npm init stencil@latest -- --info
node:internal/modules/cjs/loader:933
  const err = new Error(message);
              ^

Error: Cannot find module '../package.json'
```

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
this commit restores the --info flag, which prior to this commit would
crash.

this commit updates the `getPkgVersion` helper to throw a slightly more
helpful error when either the package.json file cannot be found or (for
some reason) the 'version' field isn't found in the file. we don't
expect the latter to ever happen, but since reading a file returns
`any`, better safe than sorry. as a part of this update, the file
containing this function was moved to typescript.

to get `version.ts` under test, a new `getPackageJson` abstraction was
added. because the CLI can be run in dev mode (where
`version.ts#getPkgVersion` sits a directory below `package.json`) and in
prod mode (where the transpiled `getPkgVersion` in `index.js` sits
adjacent to `package.json`), mocking getting the `package.json` file is
difficult when trying to exercise both the success and failure cases.
adding this abstraction allows us to mock the new function that wraps
the `require` statement much easier.

as a result of adding the abstraction, jest began to fail trying to read
`fs.rename` when importing `util.ts` in the `version.spec.ts` file.
because we're simply promisifying `fs.rename`, remove it in favor of the
native `fs.promises.rename`, which has been available since node 10


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

`npm t` was run locally and passed 🎉 

because we're changing the `rename` function (how it's promisified), I smoke tested that by spinning up a few different component libraries on this branch and a few on `main`, I compared them and ensured everything was correct insofar as renaming things goes. For example, comparing two different libraries should look something like:
```diff
diff --color -r cmp-one/package.json cmp-two/package.json
2c2
<   "name": "cmp-one",
---
>   "name": "cmp-two",
12c12
<   "unpkg": "dist/cmp-one/cmp-one.esm.js",
---
>   "unpkg": "dist/cmp-two/cmp-two.esm.js",
diff --color -r cmp-one/src/index.html cmp-two/src/index.html
8,9c8,9
<     <script type="module" src="/build/cmp-one.esm.js"></script>
<     <script nomodule src="/build/cmp-one.js"></script>
---
>     <script type="module" src="/build/cmp-two.esm.js"></script>
>     <script nomodule src="/build/cmp-two.js"></script>
diff --color -r cmp-one/stencil.config.ts cmp-two/stencil.config.ts
4c4
<   namespace: 'cmp-one',
---
>   namespace: 'cmp-two',
```
(note the lack of a '.tmp-stencil-starter' string)
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
