### PR TITLE
refactor(ci): add smoke tests for starter 

### DIFF
--- a/.github/workflows/actions/download-archive/action.yml
+++ b/.github/workflows/actions/download-archive/action.yml
@@ -1,0 +1,20 @@
+name: 'Create Stencil CLI Archive Download'
+description: 'downloads and decompresses an archive from a previous job'
+inputs:
+  path:
+    description: 'location to decompress the archive to'
+  filename:
+    description: 'the name of the decompressed artifact'
+  name:
+    description: 'name of the archive to decompress'
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+
+    - name: Extract Archive
+      run: unzip -q -o ${{ inputs.path }}/${{ inputs.filename }}
+      shell: bash

--- a/.github/workflows/actions/get-core-dependencies/action.yml
+++ b/.github/workflows/actions/get-core-dependencies/action.yml
@@ -1,0 +1,17 @@
+name: 'Get Core Dependencies'
+description: 'sets the node version & initializes core dependencies'
+runs:
+  using: composite
+  steps:
+    # this overrides previous versions of the node runtime that was set.
+    # jobs that need a different version of the Node runtime should explicitly
+    # set their node version after running this step
+    - name: Use Node Version from Volta
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+      with:
+        node-version-file: './package.json'
+        cache: 'npm'
+
+    - name: Install Dependencies
+      run: npm ci
+      shell: bash

--- a/.github/workflows/actions/upload-archive/action.yml
+++ b/.github/workflows/actions/upload-archive/action.yml
@@ -1,0 +1,20 @@
+name: 'Create Stencil CLI Archive Upload'
+description: 'compresses and uploads an archive to be reused across jobs'
+inputs:
+  paths:
+    description: 'paths to files or directories to archive (recursive)'
+  output:
+    description: 'output file name'
+  name:
+    description: 'name of the archive to upload'
+runs:
+  using: 'composite'
+  steps:
+    - name: Create Archive
+      run: zip -q -r ${{ inputs.output }} ${{ inputs.paths }}
+      shell: bash
+
+    - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.output }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build Create Stencil CLI
+
+on:
+  workflow_call:
+  # Make this a reusable workflow, no value needed
+  # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+
+jobs:
+  build_cli:
+    name: Core
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          # the pull_request_target event will consider the HEAD of `main` to be the SHA to use.
+          # attempt to use the SHA associated with a pull request and fallback to HEAD of `main`
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.number) || '' }}
+          persist-credentials: false
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: CLI Build
+        run: npm run build
+        shell: bash
+
+      - name: Unit Tests
+        run: npm test
+        shell: bash
+
+      - name: Upload Build Artifacts
+        uses: ./.github/workflows/actions/upload-archive
+        with:
+          name: stencil-cli
+          output: stencil-cli-build.zip
+          paths: index.js

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,21 @@
+name: Format Create Stencil CLI (Check)
+
+on:
+  workflow_call:
+    # Make this a reusable workflow, no value needed
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+
+jobs:
+  format:
+    name: Check Formatting
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: Prettier Check
+        run: npm run prettier.dry-run
+        shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Main
+name: CI
 
 on:
   push:
@@ -8,29 +8,20 @@ on:
     branches:
       - '**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  build_cli:
     name: Build Create Stencil CLI
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/build.yml
 
-    steps:
-      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+  format:
+    name: Format Check
+    uses: ./.github/workflows/format.yml
 
-      - name: Use Node Version from Volta
-        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
-        with:
-          node-version-file: './package.json'
-          cache: 'npm'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Prettier dry-run
-        run: npm run prettier.dry-run
-        shell: bash
-
-      - name: Build
-        run: npm run build
-
-      - name: Test
-        run: npm run test
+  smoke_test:
+    name: Smoke Testing
+    needs: [build_cli]
+    uses: ./.github/workflows/test-component-starter.yml

--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -1,0 +1,54 @@
+name: Component Starter Smoke Test
+
+on:
+  workflow_call:
+  # Make this a reusable workflow, no value needed
+  # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+
+jobs:
+  component_test:
+    name: (${{ matrix.os }}.${{ matrix.node }})
+    strategy:
+      fail-fast: false
+      matrix:
+        node: ['16', '18', '20']
+        os: ['ubuntu-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+      
+      - name: Download Build Archive
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: stencil-cli
+          path: .
+          filename: stencil-cli-build.zip
+
+      - name: Initialize the Project
+        run: node index.js component tmp-component-starter
+        shell: bash
+
+      - name: Install Component Starter Dependencies
+        run: npm install
+        working-directory: ./tmp-component-starter
+        shell: bash
+
+      - name: Build Starter Project
+        run: npm run build
+        working-directory: ./tmp-component-starter
+        shell: bash
+
+      - name: Test Starter Project
+        run: npm run test -- --no-build # the project was just built, don't build it again
+        working-directory: ./tmp-component-starter
+        shell: bash


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
our ci only unit tests the project

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the ci workflow to add support for testing the build
cli in multiple windows+node runtime environments.

the existing `main.yml` has been split into two parallel streams of
work:
```
build-->test-component-starter
format
```
where formatting occurs separate from the build/test step (as it does
not require either).

the build step now uses a reusable workflow, found
in `build.yml`. the workflow uses a new reusable action to get the
project's dependencies before building & running unit tests. upon
successful completion of both, the built project is uploaded to be used
in the `test-component-starter` workflow.

`test-component-starter` is also a resuable workflow, and is responsible
for:
- getting the built archive and decompressing it from the `build` step
- using the cli across multiple versions of operating systems and node
  runtimes
- building & testing the generated project

`test-component-starter` is designed to _not_ fail fast, such that we
can see patterns across failures to help with debugging issues (e.g. do
failures occur in older versions of node, only on windows, etc.)

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Tailed the logs to verify nothing looked awry
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

Depends on #237, which ought to land first 

Once this lands, I need to go in and update the required checks for this repo to account for the changes here
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
