### PR TITLE
feat(init): initialize a git repo on creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+coverage
 dist
 index.js
 .DS_store

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 # the output of the built project
 dist/*
 index.js
+
+# testing files
+coverage/*

--- a/src/create-app.ts
+++ b/src/create-app.ts
@@ -1,12 +1,13 @@
 import { Spinner } from 'cli-spinner';
 import fs from 'fs';
 import { join } from 'path';
-import { bold, cyan, dim, green } from 'colorette';
+import { bold, cyan, dim, green, yellow } from 'colorette';
 import { downloadStarter } from './download';
 import { Starter } from './starters';
 import { unZipBuffer } from './unzip';
 import { npm, onlyUnix, printDuration, setTmpDirectory, terminalPrompt } from './utils';
 import { replaceInFile } from 'replace-in-file';
+import { commitAllFiles, hasGit, inExistingGitTree, initGit } from './git';
 
 const starterCache = new Map<Starter, Promise<undefined | ((name: string) => Promise<void>)>>();
 
@@ -34,10 +35,20 @@ export async function createApp(starter: Starter, projectName: string, autoRun: 
   loading.stop(true);
 
   const time = printDuration(Date.now() - startT);
-  console.log(`${green('✔')} ${bold('All setup')} ${onlyUnix('🎉')} ${dim(time)}
+  let didGitSucceed = initGitForStarter(projectName);
 
+  if (didGitSucceed) {
+    console.log(`${green('✔')} ${bold('All setup')} ${onlyUnix('🎉')} ${dim(time)}`);
+  } else {
+    // an error occurred setting up git for the project. log it, but don't block creating the project
+    console.log(`${yellow('❗')} We were unable to ensure git was configured for this project.`);
+    console.log(`${green('✔')} ${bold('However, your project was still created')} ${onlyUnix('🎉')} ${dim(time)}`);
+  }
+
+  // newline here is intentional in relation to the previous logged statements
+  console.log(`
   ${dim('We suggest that you begin by typing:')}
-
+  
   ${dim(terminalPrompt())} ${green('cd')} ${projectName}
   ${dim(terminalPrompt())} ${green('npm install')}
   ${dim(terminalPrompt())} ${green('npm start')}
@@ -111,4 +122,45 @@ async function prepare(starter: Starter) {
 
 function validateProjectName(projectName: string) {
   return !/[^a-zA-Z0-9-]/.test(projectName);
+}
+
+/**
+ * Helper for performing for running through the necessary steps to create a git repository for a new project
+ * @param directory the name of the new project's directory
+ * @returns true if no issues were encountered, false otherwise
+ */
+const initGitForStarter = (directory: string): boolean => {
+  if (!changeDir(directory) || !hasGit()) {
+    // we failed to swtich to the directory to check/create the repo
+    // _or_ we didn't have `git` on the path
+    return false;
+  }
+
+  if (inExistingGitTree()) {
+    // we're already in a git tree, don't attempt to create one
+    return true;
+  }
+
+  if (!initGit()) {
+    // we failed to create a new git repo
+    return false;
+  }
+
+  return commitAllFiles();
+};
+
+/**
+ * Helper method for switching to a new directory on disk
+ * @param moveTo the directory name to switch to
+ * @returns true if the switch occurred successfully, false otherwise
+ */
+export function changeDir(moveTo: string): boolean {
+  let wasSuccess = false;
+  try {
+    process.chdir(moveTo);
+    wasSuccess = true;
+  } catch (err: unknown) {
+    console.error(err);
+  }
+  return wasSuccess;
 }

--- a/src/create-app.ts
+++ b/src/create-app.ts
@@ -125,7 +125,7 @@ function validateProjectName(projectName: string) {
 }
 
 /**
- * Helper for performing for running through the necessary steps to create a git repository for a new project
+ * Helper for performing the necessary steps to create a git repository for a new project
  * @param directory the name of the new project's directory
  * @returns true if no issues were encountered, false otherwise
  */

--- a/src/git.spec.ts
+++ b/src/git.spec.ts
@@ -1,0 +1,169 @@
+import * as cp from 'child_process';
+import { commitAllFiles, hasGit, inExistingGitTree, initGit } from './git';
+import * as Version from './version';
+
+describe('git', () => {
+  let execSyncSpy: jest.SpyInstance<ReturnType<typeof cp.execSync>, Parameters<typeof cp.execSync>>;
+
+  beforeEach(() => {
+    execSyncSpy = jest.spyOn(cp, 'execSync');
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('hasGit', () => {
+    it('returns true when git is on the path', () => {
+      execSyncSpy.mockImplementation((cmd: string, _options: cp.ExecOptions | undefined) => {
+        switch (cmd) {
+          case 'git --version':
+            return Buffer.alloc(0);
+          default:
+            throw new Error(`unmocked command ${cmd}`);
+        }
+      });
+
+      expect(hasGit()).toBe(true);
+    });
+
+    it('returns false when git is not on the path', () => {
+      execSyncSpy.mockImplementation((cmd: string, _options: cp.ExecOptions | undefined) => {
+        switch (cmd) {
+          case 'git --version':
+            throw new Error('`git` could not be found');
+          default:
+            throw new Error(`unmocked command ${cmd}`);
+        }
+      });
+
+      expect(hasGit()).toBe(false);
+    });
+  });
+
+  describe('inExistingGitTree', () => {
+    it('returns status of true when a project is in existing git repo', () => {
+      execSyncSpy.mockImplementation((cmd: string, _options: cp.ExecOptions | undefined) => {
+        switch (cmd) {
+          case 'git rev-parse --is-inside-work-tree':
+            return Buffer.alloc(0);
+          default:
+            throw new Error(`unmocked command ${cmd}`);
+        }
+      });
+
+      expect(inExistingGitTree()).toBe(true);
+    });
+
+    it('returns status of false when a project is not in existing git repo', () => {
+      execSyncSpy.mockImplementation(() => {
+        throw new Error('fatal: not a git repository (or any of the parent directories): .git');
+      });
+      expect(inExistingGitTree()).toBe(false);
+    });
+  });
+
+  describe('initGit', () => {
+    it('returns true when git is successfully initialized', () => {
+      execSyncSpy.mockImplementation((cmd: string, _options: cp.ExecOptions | undefined) => {
+        switch (cmd) {
+          case 'git init':
+            return Buffer.alloc(0);
+          default:
+            throw new Error(`unmocked command ${cmd}`);
+        }
+      });
+      expect(initGit()).toBe(true);
+    });
+
+    it('returns false when git repo initialization fails', () => {
+      execSyncSpy.mockImplementation((cmd: string, _options: cp.ExecOptions | undefined) => {
+        switch (cmd) {
+          case 'git init':
+            throw new Error('`git init` failed for some reason');
+          default:
+            throw new Error(`unmocked command ${cmd}`);
+        }
+      });
+      expect(initGit()).toBe(false);
+    });
+  });
+
+  describe('commitGit', () => {
+    const MOCK_PKG_JSON_VERSION = '3.0.0';
+    let getPkgVersionSpy: jest.SpyInstance<
+      ReturnType<typeof Version.getPkgVersion>,
+      Parameters<typeof Version.getPkgVersion>
+    >;
+
+    beforeEach(() => {
+      getPkgVersionSpy = jest.spyOn(Version, 'getPkgVersion');
+      getPkgVersionSpy.mockImplementation(() => MOCK_PKG_JSON_VERSION);
+
+      execSyncSpy.mockImplementation((cmd: string, _options: cp.ExecOptions | undefined) => {
+        switch (cmd) {
+          case 'git add -A':
+            return Buffer.alloc(0);
+          case `git commit -m "init with create-stencil v${MOCK_PKG_JSON_VERSION}"`:
+          case `git commit -m "init with create-stencil"`:
+            return Buffer.alloc(0);
+          default:
+            throw new Error(`unmocked command ${cmd}`);
+        }
+      });
+    });
+
+    afterEach(() => {
+      getPkgVersionSpy.mockRestore();
+    });
+
+    it('returns true when files are committed', () => {
+      expect(commitAllFiles()).toBe(true);
+    });
+
+    describe("'git add' fails", () => {
+      beforeEach(() => {
+        execSyncSpy.mockImplementation((cmd: string, _options: cp.ExecOptions | undefined) => {
+          switch (cmd) {
+            case 'git add -A':
+              throw new Error('git add has failed for some reason');
+            case `git commit -m "init with create-stencil v${MOCK_PKG_JSON_VERSION}"`:
+              throw new Error('git commit should not have been reached!');
+            default:
+              throw new Error(`unmocked command ${cmd}`);
+          }
+        });
+      });
+
+      it('returns false ', () => {
+        expect(commitAllFiles()).toBe(false);
+      });
+
+      it('does not attempt to commit files', () => {
+        commitAllFiles();
+
+        expect(execSyncSpy).toHaveBeenCalledTimes(1);
+        expect(execSyncSpy).toHaveBeenCalledWith('git add -A', { stdio: 'ignore' });
+      });
+    });
+
+    describe("'git commit' fails", () => {
+      it("returns false when 'git commit' fails", () => {
+        execSyncSpy.mockImplementation((cmd: string, _options: cp.ExecOptions | undefined) => {
+          switch (cmd) {
+            case 'git add -A':
+              return Buffer.alloc(0);
+            case `git commit -m "init with create-stencil v${MOCK_PKG_JSON_VERSION}"`:
+              throw new Error('git commit has failed for some reason');
+            default:
+              throw new Error(`unmocked command ${cmd}`);
+          }
+        });
+        expect(commitAllFiles()).toBe(false);
+      });
+    });
+  });
+});

--- a/src/git.ts
+++ b/src/git.ts
@@ -80,7 +80,7 @@ export const commitAllFiles = (): boolean => {
   let wasSuccess = false;
   let createStencilVersion = null;
   try {
-    createStencilVersion = `v${getPkgVersion()}`;
+    createStencilVersion = ` v${getPkgVersion()}`;
   } catch (err: unknown) {
     // do nothing - determining the CLI version isn't strictly needed for a commit message
   }
@@ -89,7 +89,7 @@ export const commitAllFiles = (): boolean => {
     // add all files (including dotfiles)
     execSync('git add -A', { stdio: 'ignore' });
     // commit them
-    const commitMessage = `init with create-stencil ${createStencilVersion ?? ''}`;
+    const commitMessage = `init with create-stencil${createStencilVersion ?? ''}`;
     execSync(`git commit -m "${commitMessage}"`, { stdio: 'ignore' });
     wasSuccess = true;
   } catch (err: unknown) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,0 +1,99 @@
+import { execSync } from 'child_process';
+import { green, yellow } from 'colorette';
+import { getPkgVersion } from './version';
+
+/**
+ * Verify that git is available on the user's path.
+ *
+ * @returns true if git is available on the user's path, false otherwise
+ */
+export const hasGit = (): boolean => {
+  let wasSuccess = false;
+  try {
+    // if `git` is not on the user's path, this will return a non-zero exit code
+    // also returns a non-zero exit code if it times out
+    execSync('git --version', { stdio: 'ignore' });
+    wasSuccess = true;
+  } catch (err: unknown) {
+    console.error(err);
+  }
+
+  return wasSuccess;
+};
+
+/**
+ * Check whether the current process is in a git work tree.
+ *
+ * This is desirable for detecting cases where a user is creating a directory inside a larger repository (e.g. monorepo)
+ *
+ * This function assumes that the process that invokes it is already in the desired directory. It also assumes that git
+ * is on the user's path.
+ *
+ * @returns true if the process is in a git repository already, false otherwise
+ */
+export const inExistingGitTree = (): boolean => {
+  let isInTree = false;
+  try {
+    // we may be in a subtree of an existing git repository (e.g. a monorepo), this call performs that check.
+    // this call is expected fail if we are _not_ in an existing repo (I.E we go all the way up the dir tree and can't
+    // find a git repo)
+    execSync('git rev-parse --is-inside-work-tree', { stdio: 'ignore' });
+
+    console.info(`${yellow('❗')} An existing git repo was detected, a new one will not be created`);
+    isInTree = true;
+  } catch (_err: unknown) {
+    console.info(`${green('✔')} A new git repo was initialized`);
+  }
+  return isInTree;
+};
+
+/**
+ * Initialize a new git repository for the current working directory of the current process.
+ *
+ * This function assumes that the process that invokes it is already in the desired directory and that the repository
+ * should be created. It also assumes that git is on the user's path.
+ *
+ * @returns true if the repository was successfully created, false otherwise
+ */
+export const initGit = (): boolean => {
+  let wasSuccess = false;
+  try {
+    // init can fail for reasons like a malformed git config, permissions, etc.
+    execSync('git init', { stdio: 'ignore' });
+    wasSuccess = true;
+  } catch (err: unknown) {
+    console.error(err);
+  }
+
+  return wasSuccess;
+};
+
+/**
+ * Stage all files and commit them for the current working directory of the current process.
+ *
+ * This function assumes that the process that invokes it is in the desired directory. It also assumes that git is on
+ * the user's path.
+ *
+ * @returns true if the files are committed successfully, false otherwise
+ */
+export const commitAllFiles = (): boolean => {
+  let wasSuccess = false;
+  let createStencilVersion = null;
+  try {
+    createStencilVersion = `v${getPkgVersion()}`;
+  } catch (err: unknown) {
+    // do nothing - determining the CLI version isn't strictly needed for a commit message
+  }
+
+  try {
+    // add all files (including dotfiles)
+    execSync('git add -A', { stdio: 'ignore' });
+    // commit them
+    const commitMessage = `init with create-stencil ${createStencilVersion ?? ''}`;
+    execSync(`git commit -m "${commitMessage}"`, { stdio: 'ignore' });
+    wasSuccess = true;
+  } catch (err: unknown) {
+    console.error(err);
+  }
+  return wasSuccess;
+};


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit updates the workflow for creating a new project to check for/create a new git repository. specifically, it:
1. ensures that the user has git on their path
2. checks that the user is not in an existing git tree a. a new tree is not created if one is found
3. intializes a new git repo
4. adds/commits all generated files

the motivation for this pull request is to set up git repo's on behalf of users, eliminating a step in the creation process. this change has an additional benefit for the stencil team by allowing minimal reproduction cases created with this cli to separate the boilerplate of a project from the reproduction related changes (via git commits).

git/prettier settings were updated to ignore the generated `coverage/` directory from jest as well

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

### Unit Tests
Tests were added for the new git utilities

### Manual
To test this manually:
1. Check out this branch
2. `npm ci && npm run build` to install deps and generate `index.js`
3. `mv index.js /tmp/ && cd /tmp` to move yourself and the built project to your `/tmp` dir
4. `node index.js` and create a new project as you normally would
5. `cd` into your new project
6. `git status` to see the current git status, `git log` to see the current log

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
### Screenshots
Output of successful init:
![Screenshot 2023-05-18 at 11 14 35 AM](https://github.com/ionic-team/create-stencil/assets/1930213/1a599494-4578-4ce9-abea-e5ed549694af)
Current output if `git.username` and `git.email` are not configured (Powershell, Windows 10):
![Screenshot 2023-05-18 081126](https://github.com/ionic-team/create-stencil/assets/1930213/8bd10504-b47a-447b-92a1-0565ed5cf634)
Current output of putting a project inside an existing git tree (Powershell, Windows 10):
![Screenshot 2023-05-18 081146](https://github.com/ionic-team/create-stencil/assets/1930213/4f8cebe9-ba4b-474b-9006-8a884e8aeec8)

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
