### PR TITLE
chore(ci): add automated dev releases

### DIFF
--- a/.github/workflows/actions/publish-npm/action.yml
+++ b/.github/workflows/actions/publish-npm/action.yml
@@ -1,0 +1,60 @@
+name: 'Publish to NPM'
+description: 'Publish the package to the NPM registry'
+inputs:
+  version:
+    description: 'The type of version to release.'
+  tag:
+    description: 'The tag to publish to on NPM.'
+  token:
+    description: 'The NPM authentication token required to publish.'
+runs:
+  using: 'composite'
+  steps:
+    # Log the input from GitHub Actions for easy traceability
+    - name: Log Inputs
+      run: |
+        echo "Version: ${{ inputs.version }}"
+        echo "Tag: ${{ inputs.tag }}"
+      shell: bash
+
+    - name: Checkout Code
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+    - name: Get Core Dependencies
+      uses: ./.github/workflows/actions/get-core-dependencies
+
+    - name: Download Build Archive
+      uses: ./.github/workflows/actions/download-archive
+      with:
+        name: stencil-cli
+        path: .
+        filename: stencil-cli-build.zip
+
+    # Remove the ZIP file after we've extracted it - we don't want this committed back to the repo
+    - name: Delete The Archive ZIP File
+      run: rm stencil-cli-build.zip
+      shell: bash
+
+    - name: Bump Version
+      run: npm version --no-git-tag-version ${{ inputs.version }}
+      shell: bash
+
+    # Log the git diff for easy debugging
+    - name: Log Generated Changes
+      run: git --no-pager diff
+      shell: bash
+
+    # Log the git status for easy debugging
+    - name: Log Status
+      run: git status
+      shell: bash
+
+    - name: Prepare NPM Token
+      run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+      shell: bash
+      env:
+        NPM_TOKEN: ${{ inputs.token }}
+
+    - name: Publish to NPM
+      run: npm publish --tag ${{ inputs.tag }} --provenance
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_cli:
-    name: Core
+    name: Build CLI
     runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout Code

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -1,0 +1,57 @@
+name: 'Dev Release'
+
+on:
+  workflow_dispatch:
+  # Make this a reusable workflow, no value needed
+  # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+
+  # TODO(NOW): Remove this
+  push:
+    branches:
+      - 'rwaskiewicz/auto-publish'
+
+jobs:
+  build_cli:
+    name: Build
+    uses: ./.github/workflows/build.yml
+
+  get_dev_version:
+    name: Get Dev Build Version
+    runs-on: ubuntu-latest
+    outputs:
+      dev-version: ${{ steps.generate-dev-version.outputs.DEV_VERSION }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+
+      - name: Generate Dev Version
+        id: generate-dev-version
+        run: |
+          PKG_JSON_VERSION=$(cat package.json | jq -r '.version')
+          GIT_HASH=$(git rev-parse --short HEAD)
+
+          # A unique string to publish the CLI under
+          # e.g. "2.1.0-dev.1677185104.7c87e34"
+          DEV_VERSION=$PKG_JSON_VERSION-dev.$(date +"%s").$GIT_HASH
+          
+          echo "Using version $DEV_VERSION"
+
+          # store a key/value pair in GITHUB_OUTPUT
+          # e.g. "DEV_VERSION=2.1.0-dev.1677185104.7c87e34"
+          echo "DEV_VERSION=$DEV_VERSION" >> $GITHUB_OUTPUT
+        shell: bash
+
+  release_create_stencil_cli:
+    name: Publish Dev Build
+    needs: [build_cli, get_dev_version]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - uses: ./.github/workflows/actions/publish-npm
+        with:
+          tag: dev
+          version: ${{ needs.get_dev_version.outputs.dev-version }}
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -5,11 +5,6 @@ on:
   # Make this a reusable workflow, no value needed
   # https://docs.github.com/en/actions/using-workflows/reusing-workflows
 
-  # TODO(NOW): Remove this
-  push:
-    branches:
-      - 'rwaskiewicz/auto-publish'
-
 jobs:
   build_cli:
     name: Build

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "create-stencil",
   "version": "3.2.0",
   "description": "Quickly create a new stencil component project: npm init stencil",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ionic-team/create-stencil"
+  },
   "main": "index.js",
   "files": [
     "index.js"


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Tests (`npm test`) were run locally and passed
- [ ] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Dev releases are manual in nature

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit implements an initial workflow for dev releases for the cli. it is capable of:
- generating a build based using the same logic as other ci workflows
- generating a dev build version
- invoking a publish action with the dev version & 'dev' tag

a new publish action is added that is capable of incrementing the version of the package and publishing changes to npm has been added. the intent is to reuse this in some capacity for production releases

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Since this is a 'dev' release, I felt safe adding a push event trigger for this branch. That way, when pushes occurred (only on this branch), I could test my changes out. Worst case scenario, a bad build made it dev.

Pushing results in provenance checks, the dev tag being applied, the correct name, and a minimal bundle:
![Screenshot 2023-05-19 at 10 50 37 AM](https://github.com/ionic-team/create-stencil/assets/1930213/c28f1705-875e-4869-8b70-72c97e1ae2f4)

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

Depends on https://github.com/ionic-team/create-stencil/pull/239
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
