### PR TITLE
fix(proxy): re-enable proxy usage

### DIFF
--- a/src/download.ts
+++ b/src/download.ts
@@ -10,9 +10,7 @@ export function downloadStarter(starter: Starter) {
 function downloadFromURL(url: string): Promise<Buffer> {
   const options = Url.parse(url);
   if (process.env['https_proxy']) {
-    // @ts-ignore
-    const agent = new HttpsProxyAgentModule.default(process.env.https_proxy);
-    // @ts-ignore
+    const agent = new HttpsProxyAgentModule.default(process.env['https_proxy']);
     options.agent = agent;
   }
   return new Promise((resolve, reject) => {

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,7 +1,7 @@
 import { get } from 'https';
 import * as Url from 'url';
 import { Starter } from './starters';
-import {HttpsProxyAgent} from 'https-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 
 export function downloadStarter(starter: Starter) {
   return downloadFromURL(`https://github.com/${starter.repo}/archive/main.zip`);

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,7 +1,7 @@
 import { get } from 'https';
 import * as Url from 'url';
 import { Starter } from './starters';
-import * as HttpsProxyAgentModule from 'https-proxy-agent';
+import {HttpsProxyAgent} from 'https-proxy-agent';
 
 export function downloadStarter(starter: Starter) {
   return downloadFromURL(`https://github.com/${starter.repo}/archive/main.zip`);
@@ -10,7 +10,8 @@ export function downloadStarter(starter: Starter) {
 function downloadFromURL(url: string): Promise<Buffer> {
   const options = Url.parse(url);
   if (process.env['https_proxy']) {
-    const agent = new HttpsProxyAgentModule.default(process.env['https_proxy']);
+    const agent = new HttpsProxyAgent(process.env['https_proxy']);
+    // @ts-ignore
     options.agent = agent;
   }
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When running with `https_proxy` set, the cli fails:
```
https_proxy=1 npm init stencil component my-project
...
$t is not a constructor
```

Note: `$t` is for Stencil v3.2.0. The variable gets renamed on each change to the codebase.

GitHub Issue Number: Fixes: https://github.com/ionic-team/create-stencil/issues/272


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

this commit fixes the import statement to pull in the correct
constructor for an Https Proxy Agent. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Running `https_proxy=1 npm init stencil component my-project` locally now attempts to reach out to the proxy correctly (it'll fail, since the proxy is literally the number 1 😆).

Verified by OP of #272 
<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
