### PR TITLE
feat(starter): allow on-prem github instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,15 +100,17 @@ npm init stencil component my-stencil-library
 ```
 In the example above, a new [component library starter](#starters) will have been created in a newly created `my-stencil-library` directory.
 
-In addition to the provided template options, users may choose to use one of their own templates.
-The template must by hosted on a public GitHub instance to use this feature.
+#### Custom Templates
+In addition to the provided template options, users may choose to use one of their own custom templates hosted on [GitHub.com](https://github.com).
 
-To use a custom starter template, provide the GitHub repository owner and repository name as your project's starter name, using the format `REPO_OWNER/REPO_NAME`.
-For example, to retrieve a template that is owned by the 'my-organization' that has the name 'my-stencil-template', the following may be used:
+To use a custom starter template, provide the GitHub repository owner and repository name as the starter name, using the format `REPO_OWNER/REPO_NAME`.
+For example, to retrieve a template that is owned by 'my-organization' that has the name 'my-stencil-template':
 ```
 npm init stencil my-organization/my-stencil-template my-stencil-library
 ```
 The command above will create a copy of the `my-organization/my-stencil-template` repository, and place it under `my-stencil-library` on disk.
+
+This can be used in conjunction with [Self Hosted GitHub Instances](#stencilselfhostedurl) to use custom starter templates that live on a self-hosted GitHub instance.
 
 ### Additional Flags
 
@@ -139,6 +141,32 @@ Stencil uses [https-proxy-agent](https://github.com/TooTallNate/proxy-agents/tre
 under the hood to connect to the specified proxy server.
 The value provided for `https_proxy` will be passed directly to the constructor for a new
 [`HttpsProxyAgent` instance](https://github.com/TooTallNate/proxy-agents/tree/main/packages/https-proxy-agent#api).
+
+#### `stencil_self_hosted_url`
+
+In some scenarios, teams may find themselves working solely out of a self-hosted GitHub instance.
+
+Users wishing to point the create-stencil CLI at a GitHub instance other than [GitHub](https://github.com) have two options:
+
+1. Set `stencil_self_hosted_url` in your `.npmrc` file, like so:
+    ```
+    // .npmrc
+    stencil_self_hosted_url=https://your_self_hosted_github_repo.com/
+    ```
+
+    Using this option, the CLI can be called as such, automatically picking up the value in `stencil_self_hosted_url`:
+    ```
+    npm init stencil [starter] [project-name]
+    ```
+
+2. Set [`stencil_self_hosted_url`](#stencilselfhostedurl) at invocation time:
+    ```console
+    stencil_self_hosted_url=https://your_self_hosted_github_repo.com/ npm init stencil
+    ```
+   
+    When using this option, `stencil_self_hosted_url` must always be set every time the CLI is called.
+
+When both options are set, the value provided on the command line takes precedence over the value in your `.npmrc` file.
 
 ## Citations
 

--- a/src/download.spec.ts
+++ b/src/download.spec.ts
@@ -32,10 +32,57 @@ describe('download', () => {
 
       expect(getStarterUrl(starter)).toBe(`https://github.com/${repo}/archive/main.zip`);
     });
+
+    describe('self-hosted url', () => {
+      afterEach(() => {
+        delete process.env['npm_config_stencil_self_hosted_url'];
+        delete process.env['stencil_self_hosted_url'];
+      });
+
+      it.each(['https://ionic.io/', 'https://ionic.io'])(
+        "returns a well formed self-hosted URL '(%s)' when npm_config_stencil_self_hosted_url is set",
+        (selfHostedUrl) => {
+          process.env['npm_config_stencil_self_hosted_url'] = selfHostedUrl;
+
+          expect(getGitHubUrl()).toBe(selfHostedUrl);
+        },
+      );
+
+      it.each(['https://ionic.io/', 'https://ionic.io'])(
+        "returns a well formed self-hosted URL '(%s)' when stencil_self_hosted_url is set",
+        (selfHostedUrl) => {
+          process.env['stencil_self_hosted_url'] = selfHostedUrl;
+
+          expect(getGitHubUrl()).toBe(selfHostedUrl);
+        },
+      );
+
+      it('uses stencil_self_hosted_url over npm_config_stencil_self_hosted_url', () => {
+        const npmConfigUrl = 'https://ionic.io/opt-1';
+
+        process.env['stencil_self_hosted_url'] = npmConfigUrl;
+        process.env['npm_config_stencil_self_hosted_url'] = 'https://ionic.io/opt-2';
+
+        expect(getGitHubUrl()).toBe(npmConfigUrl);
+      });
+    });
   });
 
   describe('getGitHubUrl', () => {
-    it('returns the default GitHub host', () => {
+    describe('self-hosted url', () => {
+      afterEach(() => {
+        delete process.env['stencil_self_hosted_url'];
+      });
+
+      it('returns a self-hosted url when one is provided', () => {
+        const mockSelfHostedUrl = 'https://ionic.io/';
+        process.env['stencil_self_hosted_url'] = mockSelfHostedUrl;
+
+        expect(getGitHubUrl()).toBe(mockSelfHostedUrl);
+      });
+    });
+
+    it('returns the default GitHub host when no self-hosted option is provided', () => {
       expect(getGitHubUrl()).toBe('https://github.com/');
     });
   });

--- a/src/download.spec.ts
+++ b/src/download.spec.ts
@@ -1,4 +1,5 @@
-import { verifyStarterExists } from './download';
+import { Starter } from './starters';
+import { getGitHubUrl, getStarterUrl, verifyStarterExists } from './download';
 
 describe('download', () => {
   describe('verifyStarterExists', () => {
@@ -18,6 +19,24 @@ describe('download', () => {
           name: 'stencil',
         }),
       ).toBe(true);
+    });
+  });
+
+  describe('getStarterUrl', () => {
+    it('returns a well formed URL from the given starter', () => {
+      const repo = 'ionic-team/mock-stencil-template';
+      const starter: Starter = {
+        name: 'test-starter',
+        repo,
+      };
+
+      expect(getStarterUrl(starter)).toBe(`https://github.com/${repo}/archive/main.zip`);
+    });
+  });
+
+  describe('getGitHubUrl', () => {
+    it('returns the default GitHub host', () => {
+      expect(getGitHubUrl()).toBe('https://github.com/');
     });
   });
 });

--- a/src/download.ts
+++ b/src/download.ts
@@ -11,12 +11,33 @@ export function downloadStarter(starter: Starter) {
   return downloadFromURL(starterUrl);
 }
 
+/**
+ * Build a URL to retrieve a starter template from a GitHub instance
+ *
+ * This function assumes that the starter will always be in a GitHub instance, as it returns a URL in string form that
+ * is specific to GitHub.
+ *
+ * @param starter metadata for the starter template to build a URL for
+ * @returns the generated URL to pull the template from
+ */
 export function getStarterUrl(starter: Starter): string {
   return new URL(`${starter.repo}/archive/main.zip`, getGitHubUrl()).toString();
 }
 
+/**
+ * Retrieve the URL for the GitHub instance to pull the starter template from
+ *
+ * This function searches for the following environment variables (in order), using the first one that is found:
+ * 1. npm_config_stencil_self_hosted_url
+ * 2. stencil_self_hosted_url
+ * 3. None - default to the publicly available GitHub instance
+ *
+ * @returns the URL for GitHub
+ */
 export function getGitHubUrl(): string {
-  return 'https://github.com/';
+  return (
+    process.env['stencil_self_hosted_url'] ?? process.env['npm_config_stencil_self_hosted_url'] ?? 'https://github.com/'
+  );
 }
 
 function getRequestOptions(starter: string | Starter) {

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,15 +1,7 @@
 import { get, request, type RequestOptions } from 'https';
-import { format } from 'util';
 import * as Url from 'url';
 import { Starter } from './starters';
 import { HttpsProxyAgent } from 'https-proxy-agent';
-
-const STARTER_URL = 'https://github.com/%s/archive/main.zip';
-
-export function downloadStarter(starter: Starter) {
-  const starterUrl = getStarterUrl(starter);
-  return downloadFromURL(starterUrl);
-}
 
 /**
  * Build a URL to retrieve a starter template from a GitHub instance
@@ -41,7 +33,7 @@ export function getGitHubUrl(): string {
 }
 
 function getRequestOptions(starter: string | Starter) {
-  const url = typeof starter === 'string' ? starter : format(STARTER_URL, starter.repo);
+  const url = typeof starter === 'string' ? starter : getStarterUrl(starter);
   const options: RequestOptions = Url.parse(url);
   if (process.env['https_proxy']) {
     const agent = new HttpsProxyAgent(process.env['https_proxy']);

--- a/src/download.ts
+++ b/src/download.ts
@@ -20,8 +20,8 @@ export function getStarterUrl(starter: Starter): string {
  * Retrieve the URL for the GitHub instance to pull the starter template from
  *
  * This function searches for the following environment variables (in order), using the first one that is found:
- * 1. npm_config_stencil_self_hosted_url
- * 2. stencil_self_hosted_url
+ * 1. stencil_self_hosted_url
+ * 2. npm_config_stencil_self_hosted_url
  * 3. None - default to the publicly available GitHub instance
  *
  * @returns the URL for GitHub

--- a/src/download.ts
+++ b/src/download.ts
@@ -6,6 +6,19 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 
 const STARTER_URL = 'https://github.com/%s/archive/main.zip';
 
+export function downloadStarter(starter: Starter) {
+  const starterUrl = getStarterUrl(starter);
+  return downloadFromURL(starterUrl);
+}
+
+export function getStarterUrl(starter: Starter): string {
+  return new URL(`${starter.repo}/archive/main.zip`, getGitHubUrl()).toString();
+}
+
+export function getGitHubUrl(): string {
+  return 'https://github.com/';
+}
+
 function getRequestOptions(starter: string | Starter) {
   const url = typeof starter === 'string' ? starter : format(STARTER_URL, starter.repo);
   const options: RequestOptions = Url.parse(url);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Users are unable to pull stater templates from on-prem instnaces of github

GitHub Issue Number: Supersedes https://github.com/ionic-team/create-stencil/pull/45 - thanks to @gfellerph for their work on this!


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

add support for self hosted github repositories. when generating the url
to download a starter from, check for the appropriate environment
variables first. 

there are two sources of configuration that are accepted - one at invocation
time (the command line) and one in `.npmrc`. see the README changes
in this commit for additional details.
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

In addition to new unit tests, this can be manually tested

1. Build the project - from the project root, `npm ci && npm run build`
2. Link the project (so we can invoke it with `npm init` later) - from the project root, `npm link`
3. Create a new directory somewhere where we don't care too much what happens to it, `mkdir /tmp/on-prem-test`
4. Copy `index.js` from the root of the project to your new directory
5. First, let's test command line invocation: `stencil_self_hosted_url=https://your_self_hosted_github_repo.com node index.js component foo-bar`. You should see an error like:
```
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'your_self_hosted_github_repo.com'
}
```
6. Next, let's test the `.npmrc` - delete `index.js` locally
7. `npm link create-stencil` from your tmp dir
8. Create an `.npmrc`: `echo stencil_self_hosted_url=https://github. > .npmrc`
9. Run `npm init stencil`. Expect an error message like that in step 5
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
