### PR TITLE
fix(init): verify starter repo exists to avoid silent interruption

### DIFF
--- a/src/download.spec.ts
+++ b/src/download.spec.ts
@@ -3,11 +3,21 @@ import { verifyStarterExists } from './download';
 describe('download', () => {
   describe('verifyStarterExists', () => {
     it('returns false if starter does not exist', async () => {
-      expect(await verifyStarterExists({ repo: 'foo/bar' } as any)).toBe(false);
+      expect(
+        await verifyStarterExists({
+          repo: 'foo/bar',
+          name: 'foo-bar-starter',
+        }),
+      ).toBe(false);
     });
 
     it('returns true if starter does exist', async () => {
-      expect(await verifyStarterExists({ repo: 'ionic-team/stencil' } as any)).toBe(true);
+      expect(
+        await verifyStarterExists({
+          repo: 'ionic-team/stencil',
+          name: 'stencil',
+        }),
+      ).toBe(true);
     });
   });
 });

--- a/src/download.spec.ts
+++ b/src/download.spec.ts
@@ -1,0 +1,13 @@
+import { verifyStarterExists } from './download';
+
+describe('download', () => {
+  describe('verifyStarterExists', () => {
+    it('returns false if starter does not exist', async () => {
+      expect(await verifyStarterExists({ repo: 'foo/bar' } as any)).toBe(false);
+    });
+
+    it('returns true if starter does exist', async () => {
+      expect(await verifyStarterExists({ repo: 'ionic-team/stencil' } as any)).toBe(true);
+    });
+  });
+});

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,4 +1,4 @@
-import { get, request, type RequestOptions, type Agent } from 'https';
+import { get, request, type RequestOptions } from 'https';
 import { format } from 'util';
 import * as Url from 'url';
 import { Starter } from './starters';

--- a/src/download.ts
+++ b/src/download.ts
@@ -1,23 +1,26 @@
-import { get } from 'https';
+import { get, request, type RequestOptions, type Agent } from 'https';
+import { format } from 'util';
 import * as Url from 'url';
 import { Starter } from './starters';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 
-export function downloadStarter(starter: Starter) {
-  return downloadFromURL(`https://github.com/${starter.repo}/archive/main.zip`);
-}
+const STARTER_URL = 'https://github.com/%s/archive/main.zip';
 
-function downloadFromURL(url: string): Promise<Buffer> {
-  const options = Url.parse(url);
+function getRequestOptions(starter: string | Starter) {
+  const url = typeof starter === 'string' ? starter : format(STARTER_URL, starter.repo);
+  const options: RequestOptions = Url.parse(url);
   if (process.env['https_proxy']) {
     const agent = new HttpsProxyAgent(process.env['https_proxy']);
-    // @ts-ignore
     options.agent = agent;
   }
-  return new Promise((resolve, reject) => {
-    get(options, (res) => {
+  return options;
+}
+
+export function downloadStarter(starter: Starter | string) {
+  return new Promise<Buffer>((resolve, reject) => {
+    get(getRequestOptions(starter), (res) => {
       if (res.statusCode === 302) {
-        downloadFromURL(res.headers.location!).then(resolve, reject);
+        downloadStarter(res.headers.location!).then(resolve, reject);
       } else {
         const data: any[] = [];
 
@@ -28,5 +31,20 @@ function downloadFromURL(url: string): Promise<Buffer> {
         res.on('error', reject);
       }
     });
+  });
+}
+
+export function verifyStarterExists(starter: Starter | string) {
+  const options = getRequestOptions(starter);
+  options.method = 'HEAD';
+  return new Promise<boolean>((resolve) => {
+    const req = request(options, (res) => {
+      res.destroy();
+      if (res.statusCode === 404) {
+        return resolve(false);
+      }
+      return resolve(true);
+    });
+    req.end();
   });
 }

--- a/src/interactive.ts
+++ b/src/interactive.ts
@@ -1,6 +1,7 @@
 import { prompt } from 'prompts';
 import { cursor, erase } from 'sisteransi';
 import { dim } from 'colorette';
+import { verifyStarterExists } from './download';
 import { createApp, prepareStarter } from './create-app';
 import { STARTERS, Starter, getStarterRepo } from './starters';
 
@@ -18,6 +19,12 @@ export async function runInteractive(starterName: string | undefined, autoRun: b
     starterName = await askStarterName();
   }
   const starter = getStarterRepo(starterName);
+
+  // verify that the starter exists
+  const starterExist = await verifyStarterExists(starter);
+  if (!starterExist) {
+    throw new Error(`Starter template "${starter.repo}" not found`);
+  }
 
   // start downloading in the background
   prepareStarter(starter);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Tests (`npm test`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?

When running with a starter parameter that does not resolve to a GitHub repository, e.g. `npm init stencil foo/bar` the command silently fails:

![bug-demo](https://github.com/ionic-team/create-stencil/assets/731337/76751680-01b8-4a00-8831-6cc604c63dc5)


## What is the new behavior?

We run a `HEAD` request to verify the request won't 404. There are more opportunities here to do more status checks but I want to keep it simple for now:

![bug-fix](https://github.com/ionic-team/create-stencil/assets/731337/80894360-dc3d-4032-a9eb-30fc86822b0f)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

I've added unit tests for the new function I added. Happy to add more if needed.

## Other information

Explored this issue when I onboarded myself on various projects. My default thinking was that the `init` command allows me to provide a path to the project as it is with many other tools. This conflicted however with the way this starter works.
