### PR TITLE
chore(renovate): group download & upload artifact

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -50,7 +50,12 @@
     {
       matchPackageNames: ['rollup'],
       matchPackagePrefixes: ['@rollup'],
-      groupName: 'rollup,'
+      groupName: 'rollup'
+    },
+    {
+      // group these two, as they may rely on one another during major version bumps
+      matchPackageNames: ['actions/download-artifact', 'actions/upload-artifact'],
+      groupName: 'Download + Upload Artifacts',
     }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `actions/upload-artifact` and `actions/download-artifact` are not grouped despite their shared peer dependencies on one another.

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Creates a group in the Renovate config to group `actions/upload-artifact` and `actions/download-artifact`.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Merge and find out

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
